### PR TITLE
Fix username and add dimension to result

### DIFF
--- a/src/main/java/space/bbkr/where/Where.java
+++ b/src/main/java/space/bbkr/where/Where.java
@@ -35,9 +35,11 @@ public class Where implements ModInitializer {
 										}
 									}
 
-									context.getSource().sendFeedback(target.getDisplayName().copy()
+									context.getSource().sendFeedback(new LiteralText(target.getName().asString())
 											.append(" is at " + target.getBlockPos().getX() + ", "
-													+ target.getBlockPos().getY() + ", " + target.getBlockPos().getZ()),
+													+ target.getBlockPos().getY() + ", " + target.getBlockPos().getZ()
+                                                                                                        + " in " 
+												        + target.getEntityWorld().getRegistryKey().getValue().toString()),
 											true);
 									return 1;
 								})


### PR DESCRIPTION
This fixes an issue where if a player is on a team with a colored name, no name will be shown in chat. Instead, we display the raw username without any formatting or coloring. Not sure if there is a better way but this worked for me. Additionally, this PR adds the current dimension of the player to the result which is also helpful.